### PR TITLE
Update PacketEvents to 2.8.1-SNAPSHOT

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -77,7 +77,7 @@ tasks {
     )
 
     val sharedBukkitPlugins = runPaper.downloadPluginsSpec {
-        url("https://cdn.modrinth.com/data/HYKaKraK/versions/2HJtPM2W/packetevents-spigot-2.8.0.jar")
+        url("https://ci.codemc.io/job/retrooper/job/packetevents/lastSuccessfulBuild/artifact/spigot/build/libs/packetevents-spigot-2.8.1-SNAPSHOT.jar")
         url("https://github.com/ViaVersion/ViaVersion/releases/download/5.3.2/ViaVersion-5.3.2.jar")
         url("https://github.com/ViaVersion/ViaBackwards/releases/download/5.3.2/ViaBackwards-5.3.2.jar")
     }
@@ -125,7 +125,7 @@ tasks {
         }
 
         downloadPlugins {
-            url("https://ci.codemc.io/job/retrooper/job/packetevents/lastSuccessfulBuild/artifact/velocity/build/libs/packetevents-velocity-2.6.1-SNAPSHOT.jar")
+            url("https://ci.codemc.io/job/retrooper/job/packetevents/lastSuccessfulBuild/artifact/velocity/build/libs/packetevents-velocity-2.8.1-SNAPSHOT.jar")
             url("https://ci.lucko.me/job/spark/418/artifact/spark-velocity/build/libs/spark-1.10.73-velocity.jar")
         }
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 adventure = "4.21.0"
-packetevents = "2.8.0"
+packetevents = "2.8.1-SNAPSHOT"
 betterreload = "v1.0.0"
 guava = "33.3.1-jre"
 paper = "1.21.5-R0.1-SNAPSHOT"

--- a/platforms/sponge/build.gradle.kts
+++ b/platforms/sponge/build.gradle.kts
@@ -42,7 +42,7 @@ sponge {
             }
             dependency("packetevents") {
                 loadOrder(PluginDependency.LoadOrder.AFTER)
-                version("2.5.1-SNAPSHOT")
+                version("2.8.1-SNAPSHOT")
                 optional(false)
             }
         }


### PR DESCRIPTION
## Summary
- use PacketEvents 2.8.1-SNAPSHOT for library versions
- update run task plugin jars for Bukkit and Velocity to snapshot builds
- change Sponge platform's PacketEvents dependency accordingly

## Testing
- `./gradlew build --offline` *(fails: No route to host)*