### PR TITLE
Use PacketEvents 2.8.1-SNAPSHOT

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -77,7 +77,7 @@ tasks {
     )
 
     val sharedBukkitPlugins = runPaper.downloadPluginsSpec {
-        url("https://cdn.modrinth.com/data/HYKaKraK/versions/2HJtPM2W/packetevents-spigot-2.8.0.jar")
+        url("https://cdn.modrinth.com/data/HYKaKraK/versions/2HJtPM2W/packetevents-spigot-2.8.1-SNAPSHOT.jar")
         url("https://github.com/ViaVersion/ViaVersion/releases/download/5.3.2/ViaVersion-5.3.2.jar")
         url("https://github.com/ViaVersion/ViaBackwards/releases/download/5.3.2/ViaBackwards-5.3.2.jar")
     }
@@ -125,7 +125,7 @@ tasks {
         }
 
         downloadPlugins {
-            url("https://ci.codemc.io/job/retrooper/job/packetevents/lastSuccessfulBuild/artifact/velocity/build/libs/packetevents-velocity-2.6.1-SNAPSHOT.jar")
+            url("https://ci.codemc.io/job/retrooper/job/packetevents/lastSuccessfulBuild/artifact/velocity/build/libs/packetevents-velocity-2.8.1-SNAPSHOT.jar")
             url("https://ci.lucko.me/job/spark/418/artifact/spark-velocity/build/libs/spark-1.10.73-velocity.jar")
         }
     }

--- a/common/src/main/java/com/deathmotion/antihealthindicator/cache/trackers/VehicleTracker.java
+++ b/common/src/main/java/com/deathmotion/antihealthindicator/cache/trackers/VehicleTracker.java
@@ -33,8 +33,11 @@ import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerAt
 import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerEntityMetadata;
 import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerSetPassengers;
 import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerUpdateAttributes;
+import com.github.retrooper.packetevents.protocol.entity.attribute.Attribute;
+import com.github.retrooper.packetevents.protocol.entity.attribute.Attributes;
 
 import java.util.Collections;
+import java.util.Arrays;
 
 public class VehicleTracker {
     private final AHIPlayer player;
@@ -133,11 +136,17 @@ public class VehicleTracker {
     private void sendAttributes(int vehicleId) {
         // Sends cached attribute values back to the rider.
         AHIPlatform.getInstance().getScheduler().runAsyncTask(task -> {
-            // Placeholder implementation; actual packet fields depend on PacketEvents.
             RidableEntity r = (RidableEntity) cache.getEntityRaw(vehicleId);
             if (r == null) return;
-            // TODO: construct WrapperPlayServerUpdateAttributes packet with cached values
-            // player.user.sendPacketSilently(new WrapperPlayServerUpdateAttributes(...));
+
+            Attribute speed = new Attribute(Attributes.GENERIC_MOVEMENT_SPEED, r.getMaxSpeed());
+            Attribute jump = new Attribute(Attributes.HORSE_JUMP_STRENGTH, r.getJumpStrength());
+            Attribute llama = new Attribute(Attributes.LLAMA_STRENGTH, r.getLlamaInventorySlots());
+
+            player.user.sendPacketSilently(new WrapperPlayServerUpdateAttributes(
+                    vehicleId,
+                    Arrays.asList(speed, jump, llama)
+            ));
         });
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 adventure = "4.21.0"
-packetevents = "2.8.0"
+packetevents = "2.8.1-SNAPSHOT"
 betterreload = "v1.0.0"
 guava = "33.3.1-jre"
 paper = "1.21.5-R0.1-SNAPSHOT"

--- a/platforms/sponge/build.gradle.kts
+++ b/platforms/sponge/build.gradle.kts
@@ -42,7 +42,7 @@ sponge {
             }
             dependency("packetevents") {
                 loadOrder(PluginDependency.LoadOrder.AFTER)
-                version("2.5.1-SNAPSHOT")
+                version("2.8.1-SNAPSHOT")
                 optional(false)
             }
         }


### PR DESCRIPTION
## Summary
- fix PacketEvents version after invalid 2.9.0 bump
- update included plugin jars for run tasks
- adjust Sponge plugin dependency
- implement VehicleTracker attribute updates

## Testing
- `gradle build` *(fails: could not resolve com.gradle.enterprise plugin)*