### PR TITLE
Add ride stats spoofer improvements and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,21 @@ The plugin includes various spoofing features:
 - Item Durability
 - Item Enchantments
 - Item Stack Amount
+- Ride Stats (speed, jump height, max health, llama slots)
+
+### Ride Stats Configuration
+
+Add the following section to `config.yml` to control spoofing values:
+
+```yaml
+spoof:
+  ride-stats:
+    enabled: true       # Master toggle for ride stats spoofing
+    speed: true         # Mask movement speed
+    jump-height: true   # Mask jump height
+    max-health: true    # Mask maximum health
+    llama-slots: true   # Mask llama inventory slots
+```
 
 ## Commands
 

--- a/common/src/main/java/com/deathmotion/antihealthindicator/data/Settings.java
+++ b/common/src/main/java/com/deathmotion/antihealthindicator/data/Settings.java
@@ -32,6 +32,7 @@ public class Settings {
     private boolean teamScoreboard = true;
     private EntityData entityData = new EntityData();
     private Items items = new Items();
+    private RideStats rideStats = new RideStats();
 
     @Getter
     @Setter
@@ -82,5 +83,15 @@ public class Settings {
         private boolean brokenElytra = true;
 
         private boolean enchantments = true;
+    }
+
+    @Getter
+    @Setter
+    public static class RideStats {
+        private boolean enabled = true;
+        private boolean speed = true;
+        private boolean jumpHeight = true;
+        private boolean maxHealth = true;
+        private boolean llamaSlots = true;
     }
 }

--- a/common/src/main/java/com/deathmotion/antihealthindicator/managers/ConfigManager.java
+++ b/common/src/main/java/com/deathmotion/antihealthindicator/managers/ConfigManager.java
@@ -98,6 +98,7 @@ public class ConfigManager<P> {
 
         setEntityDataOptions(yamlData, settings);
         setItemOptions(yamlData, settings);
+        setRideStatsOptions(yamlData, settings);
     }
 
     private void setEntityDataOptions(Map<String, Object> yamlData, Settings settings) {
@@ -121,6 +122,14 @@ public class ConfigManager<P> {
         settings.getItems().setDurability(getBoolean(yamlData, "spoof.entity-data.items.durability.enabled", true));
         settings.getItems().setBrokenElytra(getBoolean(yamlData, "spoof.entity-data.items.durability.broken-elytra.enabled", true));
         settings.getItems().setEnchantments(getBoolean(yamlData, "spoof.entity-data.items.enchantments.enabled", true));
+    }
+
+    private void setRideStatsOptions(Map<String, Object> yamlData, Settings settings) {
+        settings.getRideStats().setEnabled(getBoolean(yamlData, "spoof.ride-stats.enabled", true));
+        settings.getRideStats().setSpeed(getBoolean(yamlData, "spoof.ride-stats.speed", true));
+        settings.getRideStats().setJumpHeight(getBoolean(yamlData, "spoof.ride-stats.jump-height", true));
+        settings.getRideStats().setMaxHealth(getBoolean(yamlData, "spoof.ride-stats.max-health", true));
+        settings.getRideStats().setLlamaSlots(getBoolean(yamlData, "spoof.ride-stats.llama-slots", true));
     }
 
     private boolean getBoolean(Map<String, Object> yamlData, String key, boolean defaultValue) {

--- a/common/src/main/java/com/deathmotion/antihealthindicator/managers/SpoofManager.java
+++ b/common/src/main/java/com/deathmotion/antihealthindicator/managers/SpoofManager.java
@@ -36,6 +36,7 @@ public class SpoofManager {
                 .put(GamemodeSpoofer.class, new GamemodeSpoofer(player))
                 .put(ScoreboardSpoofer.class, new ScoreboardSpoofer(player))
                 .put(FoodSaturationSpoofer.class, new FoodSaturationSpoofer(player))
+                .put(RideStatsSpoofer.class, new RideStatsSpoofer(player))
                 .build();
     }
 

--- a/common/src/main/java/com/deathmotion/antihealthindicator/spoofers/impl/RideStatsSpoofer.java
+++ b/common/src/main/java/com/deathmotion/antihealthindicator/spoofers/impl/RideStatsSpoofer.java
@@ -1,0 +1,109 @@
+/*
+ *  This file is part of AntiHealthIndicator - https://github.com/Bram1903/AntiHealthIndicator
+ *  Copyright (C) 2025 Bram and contributors
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.deathmotion.antihealthindicator.spoofers.impl;
+
+import com.deathmotion.antihealthindicator.data.AHIPlayer;
+import com.deathmotion.antihealthindicator.data.Settings;
+import com.deathmotion.antihealthindicator.spoofers.Spoofer;
+import com.github.retrooper.packetevents.event.PacketSendEvent;
+import com.github.retrooper.packetevents.protocol.entity.data.EntityData;
+import com.github.retrooper.packetevents.protocol.entity.data.EntityDataTypes;
+import com.github.retrooper.packetevents.protocol.entity.type.EntityType;
+import com.github.retrooper.packetevents.protocol.packettype.PacketType;
+import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerEntityMetadata;
+import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerUpdateAttributes;
+import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerUpdateAttributes.Property;
+
+import java.util.List;
+
+/**
+ * Spoofs riding statistics such as max health, speed and jump height of rideable entities.
+ */
+public final class RideStatsSpoofer extends Spoofer {
+
+    private static final String GENERIC_MAX_HEALTH = "generic.max_health";
+    private static final String GENERIC_MOVEMENT_SPEED = "generic.movement_speed";
+    private static final String HORSE_JUMP_STRENGTH = "horse.jump_strength";
+
+
+    public RideStatsSpoofer(AHIPlayer player) {
+        super(player);
+    }
+
+    @Override
+    public void onPacketSend(PacketSendEvent event) {
+        Settings.RideStats settings = configManager.getSettings().getRideStats();
+        if (!settings.isEnabled()) return;
+
+        if (event.getPacketType() == PacketType.Play.Server.ENTITY_PROPERTIES) {
+            handleEntityProperties(event, settings);
+        } else if (event.getPacketType() == PacketType.Play.Server.ENTITY_METADATA) {
+            handleEntityMetadata(event, settings);
+        }
+    }
+
+    private void handleEntityProperties(PacketSendEvent event, Settings.RideStats settings) {
+        WrapperPlayServerUpdateAttributes packet = new WrapperPlayServerUpdateAttributes(event);
+        List<Property> properties = packet.getProperties();
+        boolean modified = false;
+
+        for (Property property : properties) {
+            String key = property.getKey();
+            if (GENERIC_MAX_HEALTH.equals(key) && settings.isMaxHealth()) {
+                property.setBaseValue(20.0);
+                modified = true;
+            } else if (GENERIC_MOVEMENT_SPEED.equals(key) && settings.isSpeed()) {
+                property.setBaseValue(0.1);
+                modified = true;
+            } else if (HORSE_JUMP_STRENGTH.equals(key) && settings.isJumpHeight()) {
+                property.setBaseValue(0.5);
+                modified = true;
+            }
+        }
+
+        if (modified) {
+            packet.setProperties(properties);
+            event.markForReEncode(true);
+        }
+    }
+
+    private void handleEntityMetadata(PacketSendEvent event, Settings.RideStats settings) {
+        WrapperPlayServerEntityMetadata packet = new WrapperPlayServerEntityMetadata(event);
+        EntityType type = packet.getEntityType();
+        if (type == null || !type.name().contains("LLAMA")) return;
+
+        List<EntityData<?>> dataList = packet.getEntityMetadata();
+        boolean modified = false;
+
+        int llamaIndex = player.metadataIndex.LLAMA_STRENGTH;
+        for (EntityData<?> data : dataList) {
+            if (data.getIndex() == llamaIndex && settings.isLlamaSlots()) {
+                if (data.getType() == EntityDataTypes.INT) {
+                    ((EntityData<Integer>) data).setValue(0);
+                    modified = true;
+                }
+            }
+        }
+
+        if (modified) {
+            packet.setEntityMetadata(dataList);
+            event.markForReEncode(true);
+        }
+    }
+}

--- a/common/src/main/java/com/deathmotion/antihealthindicator/util/MetadataIndex.java
+++ b/common/src/main/java/com/deathmotion/antihealthindicator/util/MetadataIndex.java
@@ -30,6 +30,7 @@ public class MetadataIndex {
     public final int XP;
     public final int TAMABLE_TAMED;
     public final int TAMABLE_OWNER;
+    public final int LLAMA_STRENGTH;
 
     public MetadataIndex(ClientVersion version) {
         if (!AHIPlatform.getInstance().isProxy()) {
@@ -42,6 +43,7 @@ public class MetadataIndex {
         XP = getXPIndex(version);
         TAMABLE_TAMED = getTameIndex(version);
         TAMABLE_OWNER = getOwnerIndex(version);
+        LLAMA_STRENGTH = getLlamaStrengthIndex(version);
     }
 
     private int getHealthIndex(ClientVersion version) {
@@ -111,6 +113,16 @@ public class MetadataIndex {
             return 16;
         } else if (version.isNewerThanOrEquals(ClientVersion.V_1_12)) {
             return 14;
+        } else {
+            return 17;
+        }
+    }
+
+    private int getLlamaStrengthIndex(ClientVersion version) {
+        if (version.isNewerThanOrEquals(ClientVersion.V_1_17)) {
+            return 20;
+        } else if (version.isNewerThanOrEquals(ClientVersion.V_1_13)) {
+            return 19;
         } else {
             return 17;
         }

--- a/common/src/main/resources/config.yml
+++ b/common/src/main/resources/config.yml
@@ -127,3 +127,10 @@ spoof:
       # client-side, otherwise the client will render the item as if not enchanted.
       enchantments:
         enabled: true
+
+  ride-stats:
+    enabled: true
+    speed: true
+    jump-height: true
+    max-health: true
+    llama-slots: true


### PR DESCRIPTION
## Summary
- fix packet wrapper in `RideStatsSpoofer`
- use dynamic llama strength metadata index
- document ride stats spoofer in README

## Testing
- `gradle help --no-daemon --offline` *(fails: plugin com.gradle.enterprise not found)*